### PR TITLE
Send signer roles as json on `create_embedded_template_draft`

### DIFF
--- a/lib/hello_sign/api/template.rb
+++ b/lib/hello_sign/api/template.rb
@@ -176,6 +176,7 @@ module HelloSign
         prepare_files opts
         prepare_signer_roles opts
         prepare_attachments opts
+        prepare_merge_fields opts
         HelloSign::Resource::TemplateDraft.new post("/template/create_embedded_draft", body: opts)
       end
 

--- a/spec/fixtures/template_draft.json
+++ b/spec/fixtures/template_draft.json
@@ -1,0 +1,7 @@
+{
+  "template": {
+      "template_id": "a364138e0d8ae6393aa425a8ec64715580f3748b",
+      "edit_url": "https://embedded.hellosign.com/prep-and-send/embedded-template?cached_params_token=xxxxxxxxx",
+      "expires_at": 1649096573
+  }
+}

--- a/spec/hello_sign/api/template_spec.rb
+++ b/spec/hello_sign/api/template_spec.rb
@@ -169,4 +169,36 @@ describe HelloSign::Api::Template do
       expect(@template.headers).to_not be_nil
     end
   end
+
+  describe '#create_embedded_template_draft' do
+    before do
+      stub_post('/template/create_embedded_draft', 'template_draft')
+      @template_draft = HelloSign.create_embedded_template_draft :title => 'Document Test', :file_url => 'http://hellosign.com/test.pdf'
+    end
+
+    it 'should return a Template Draft' do
+      expect(@template_draft).to be_an HelloSign::Resource::TemplateDraft
+    end
+
+    it 'should return response headers' do
+      expect(@template_draft.headers).to_not be_nil
+    end
+
+    context 'with multiple signer_roles' do
+      before do
+        stub_post('/template/create_embedded_draft', 'template_draft')
+        @template_draft = HelloSign.create_embedded_template_draft(
+          :title => 'Document Test',
+          :file_url => 'http://hellosign.com/test.pdf',
+          :signer_roles => [{ :name => 'Employee' }, { :name => 'CEO' }]
+        )
+      end
+
+      it 'should send signer_roles as json' do
+        expect(a_post('/template/create_embedded_draft').with(
+          :body => hash_including({ :signer_roles => [{ :name => 'Employee' }, { :name => 'CEO' }] }))
+        ).to have_been_made
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix for Issue #1 